### PR TITLE
set last_timer_val  at  canopen_timer_thread_entry

### DIFF
--- a/src/timer_rtthread.c
+++ b/src/timer_rtthread.c
@@ -48,6 +48,7 @@ static void canopen_timer_thread_entry(void* parameter)
 	{
 		rt_sem_take(canfstvl_timer_sem, RT_WAITING_FOREVER);
 		EnterMutex();
+		rt_device_read(canfstvl_timer_dev, 0, &last_timer_val, sizeof(last_timer_val));
 		TimeDispatch();
 		LeaveMutex();
 	}
@@ -56,7 +57,6 @@ static void canopen_timer_thread_entry(void* parameter)
 
 static rt_err_t timer_timeout_cb(rt_device_t dev, rt_size_t size)
 {
-    rt_device_read(canfstvl_timer_dev, 0, &last_timer_val, sizeof(last_timer_val));
 	rt_sem_release(canfstvl_timer_sem);
     
     return RT_EOK;


### PR DESCRIPTION
Canfestival 从站sdo接收场景下 定时器超时 导致复位该line
![image](https://user-images.githubusercontent.com/6029154/64250670-5066fe00-cf49-11e9-8ce5-4cd6a4a7d54c.png)
原因分析：心跳间隔设置为10s， sdo超时设置为3s，当心跳定时产生中断时未来得及处理中断内容，此事处理sdo init下载导致定时3s的定时器定时了，然后去处理定时中断时，定时3s被误当作定时已经完成，sdo timeout。
![image](https://user-images.githubusercontent.com/6029154/64250685-5ceb5680-cf49-11e9-9a6b-900f1256b190.png)
修改方案：在中断未处理前， sdo init 里面不进行定时，即            if (total_sleep_time > elapsed_time && total_sleep_time - elapsed_time > real_timer_value) 条件不成立
即elapsed_time值不能在定时中断产生时立即设置为0（不能此时读取last_timer_val），需要在处理中断时读取last_timer_val值。